### PR TITLE
fix: ensure all params are checked

### DIFF
--- a/src/middleware/require-query-param.js
+++ b/src/middleware/require-query-param.js
@@ -1,5 +1,5 @@
 export const requireQueryParam = (paramNames, errorMessage) => (req, res, next) => {
-    const name = (paramNames.map(name => req.query[name]).filter(name => name !== undefined)[0] || '').toLowerCase();
+    const name = (paramNames.map(name => req.query[name]).find(name => name !== undefined) || '').toLowerCase();
     if (name) {
         if (!req.opts) req.opts = {};
         req.opts.name = name;


### PR DESCRIPTION
Fixes `name` being used as query param.

https://ghprofile.me/?name=TrustedMercury-ghprofile.me
https://ghprofile.me/?username=TrustedMercury-ghprofile.me

Signed-off-by: Alexis Tyler <xo@wvvw.me>